### PR TITLE
Bugfix: Align db path to make CLI binary working 

### DIFF
--- a/.clojure-skills/config.edn
+++ b/.clojure-skills/config.edn
@@ -1,4 +1,4 @@
-{:database {:path "~/dev/clojure-skills/clojure-skills.db",
+{:database {:path "~/.config/clojure-skills/clojure-skills.db",
             :auto-migrate true},
  :project {:root nil,
            :skills-dir "skills",


### PR DESCRIPTION
Experienced the issue while using native build CLI, due tp initially the db has been initialized in `~/dev/clojure-skills/clojure-skills.db`  (i.e. from this project root)
But while further usage of the binary, the default db path (`~/.config/clojure-skills/config.edn`) priority list is the following:
```
  Configuration priority:
  1. Environment variables
  2. Project config (.clojure-skills/config.edn)
  3. ~/.config/clojure-skills/config.edn
  4. Built-in defaults"
```
bug:
````
java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit               LambdaForm$DMH
                                  clojure_skills.main.main
                                 clojure-skills.main/-main                     main.clj:   8
                                 clojure-skills.main/-main                     main.clj:  11
                                clojure-skills.cli/run-cli                      cli.clj: 604
                                    cli-matic.core/run-cmd                    core.cljc: 601
                                   cli-matic.core/run-cmd*                    core.cljc: 589
                              cli-matic.core/invoke-subcmd                    core.cljc: 546
                              clojure-skills.cli/cmd-stats                      cli.clj: 406
                  clojure-skills.cli/handle-command-errors                      cli.clj:  79
                  clojure-skills.cli/handle-command-errors                      cli.clj:  83
                           clojure-skills.cli/cmd-stats/fn                      cli.clj: 410
                           clojure-skills.search/get-stats                   search.clj: 107
                                    next.jdbc/execute-one!                     jdbc.clj: 273
                                  next.jdbc.protocols/fn/G                protocols.clj:  34
                                   next.jdbc.result-set/fn               result_set.clj:1020
                                  next.jdbc.protocols/fn/G                protocols.clj:  34
                                   next.jdbc.result-set/fn               result_set.clj: 922
                                  next.jdbc.prepare/create                  prepare.clj: 134
         org.sqlite.jdbc3.JDBC3Connection.prepareStatement         JDBC3Connection.java: 205
         org.sqlite.jdbc3.JDBC3Connection.prepareStatement         JDBC3Connection.java: 225
         org.sqlite.jdbc4.JDBC4Connection.prepareStatement         JDBC4Connection.java:  34
            org.sqlite.jdbc4.JDBC4PreparedStatement.<init>  JDBC4PreparedStatement.java:  25
            org.sqlite.jdbc3.JDBC3PreparedStatement.<init>  JDBC3PreparedStatement.java:  32
              org.sqlite.core.CorePreparedStatement.<init>   CorePreparedStatement.java:  46
                                org.sqlite.core.DB.prepare                      DB.java: 264
                          org.sqlite.core.NativeDB.prepare                NativeDB.java: 135
                     org.sqlite.core.NativeDB.prepare_utf8                NativeDB.java
                                org.sqlite.core.DB.throwex                      DB.java:1150
                        org.sqlite.core.DB.newSQLException                      DB.java:1190
                        org.sqlite.core.DB.newSQLException                      DB.java:1179
org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (no such table: skills)
````
